### PR TITLE
feat(text-format: Change date formatter to use shorter strings)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,19 +17,19 @@ export function formatDate(date, now) {
   } else if (d < hourSeconds) {
     const minutes = Math.floor(d / minuteSeconds)
     return {
-      value: `${minutes} minutes ago`,
+      value: `${minutes}m ago`,
       next: minuteSeconds - d % 60,
     }
   } else if (d < daySeconds) {
     const hours = Math.floor(d / hourSeconds)
     return {
-      value: `${hours} hour${hours > 1 ? `s` : ``} ago`,
+      value: `${hours}h ago`,
       next: hourSeconds - d % hourSeconds,
     }
   } else {
     const days = Math.floor(d / daySeconds)
     return {
-      value: `${days} day${days > 1 ? `s` : ``} ago`,
+      value: `${days}d ago`,
       next: daySeconds - d % daySeconds,
     }
   }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -14,17 +14,17 @@ describe(`formatDate`, () => {
   each([
     [initial, initial, `now`, 120],
     [initial, initial + 119, `now`, 1],
-    [initial, initial + 120, `2 minutes ago`, 60],
-    [initial, initial + 121, `2 minutes ago`, 59],
-    [initial, initial + 60 * 59, `59 minutes ago`, 60],
-    [initial, initial + 60 * 59 + 59, `59 minutes ago`, 1],
-    [initial, initial + 60 * 60, `1 hour ago`, 3600],
-    [initial, initial + 60 * 60 * 2 - 1, `1 hour ago`, 1],
-    [initial, initial + 60 * 120, `2 hours ago`, 3600],
-    [initial, initial + 60 * 60 * 24 - 1, `23 hours ago`, 1],
-    [initial, initial + 60 * 60 * 24, `1 day ago`, 60 * 60 * 24],
-    [initial, initial + 60 * 60 * 24 * 2, `2 days ago`, 60 * 60 * 24],
-    [initial, initial + 60 * 60 * 24 * 2 + 3, `2 days ago`, 60 * 60 * 24 - 3],
+    [initial, initial + 120, `2m ago`, 60],
+    [initial, initial + 121, `2m ago`, 59],
+    [initial, initial + 60 * 59, `59m ago`, 60],
+    [initial, initial + 60 * 59 + 59, `59m ago`, 1],
+    [initial, initial + 60 * 60, `1h ago`, 3600],
+    [initial, initial + 60 * 60 * 2 - 1, `1h ago`, 1],
+    [initial, initial + 60 * 120, `2h ago`, 3600],
+    [initial, initial + 60 * 60 * 24 - 1, `23h ago`, 1],
+    [initial, initial + 60 * 60 * 24, `1d ago`, 60 * 60 * 24],
+    [initial, initial + 60 * 60 * 24 * 2, `2d ago`, 60 * 60 * 24],
+    [initial, initial + 60 * 60 * 24 * 2 + 3, `2d ago`, 60 * 60 * 24 - 3],
   ]).test(
     `returns the correct value for the start date %s and the current date %s which is '%s' and the next update in %s seconds`,
     (date, now, value, next) => {
@@ -61,7 +61,7 @@ describe(`createTimeAgoObservable`, () => {
       itemCounter++
       emittedValues.push(value)
       if (itemCounter > 1) {
-        expect(emittedValues).toEqual([`now`, `2 minutes ago`])
+        expect(emittedValues).toEqual([`now`, `2m ago`])
         done()
       }
     })
@@ -78,7 +78,7 @@ describe(`createTimeAgoObservable`, () => {
     clock.tick(`05:00`)
 
     observable.subscribe(value => {
-      expect(value).toEqual(`5 minutes ago`)
+      expect(value).toEqual(`5m ago`)
       done()
     })
     clock.uninstall()
@@ -124,11 +124,11 @@ describe(`<TimeAgo />`, () => {
         clock.tick(`02:00`)
       })
       .then(() => {
-        expect(element.text()).toEqual(`2 minutes ago`)
+        expect(element.text()).toEqual(`2m ago`)
         clock.tick(`01:00:00`)
       })
       .then(() => {
-        expect(element.text()).toEqual(`1 hour ago`)
+        expect(element.text()).toEqual(`1h ago`)
         element.unmount()
         clock.uninstall()
         done()


### PR DESCRIPTION
Example: 1 minute ago -> 1m ago, 5

BREAKING CHANGE: The default formatted texts have changed. You can still use the default formatting
by providing your own custom formatData function.